### PR TITLE
Add WYSIWYG editor to ParagraphCta new and edit forms

### DIFF
--- a/Test/Controller/ParagraphCta.hs
+++ b/Test/Controller/ParagraphCta.hs
@@ -1,0 +1,61 @@
+module Test.Controller.ParagraphCta where
+
+import Network.HTTP.Types.Status
+
+import IHP.Prelude
+import IHP.QueryBuilder (query)
+import IHP.Test.Mocking
+import IHP.Fetch
+
+import IHP.FrameworkConfig
+import IHP.HaskellSupport
+import IHP.ModelSupport
+import Test.Hspec
+import Config
+
+import Generated.Types
+import Web.Routes
+import Web.Types
+import Web.FrontController
+import Web.Controller.ParagraphCtas
+import Network.Wai
+import IHP.ControllerPrelude
+
+import Text.HTML.TagSoup
+import Text.HTML.TagSoup.Match
+
+tests :: Spec
+tests = aroundAll (withIHPApp WebApplication config) do
+        describe "ParagraphCta View (via LandingPages)" do
+            it "Create 2 landing pages (1 for CTA and 1 for reference) and 1 CTA.\nThen check that only saniitzed HTML is shown." $ withContext do
+                testLandingPage <- newRecord @LandingPage |> createRecord
+                testRefLandingPage <- newRecord @LandingPage |> createRecord
+
+                count <- query @LandingPage |> fetchCount
+                count `shouldBe` 2
+
+                _ <- callActionWithParams
+                        CreateParagraphCtaAction
+                        [ ("landingPageId", idToParam testLandingPage.id)
+                        , ("weight", "0") -- Irrelevant so setting to 0
+                        , ("title", "Malicious CTA")
+                        , ("body", "<script>doBadStuff()</script>")
+                        , ("refLandingPageId", idToParam testRefLandingPage.id)
+                        ]
+                
+                count <- query @ParagraphCta |> fetchCount
+                count `shouldBe` 1
+
+                response <- mockAction (ShowLandingPageAction testLandingPage.id)
+
+                response `responseStatusShouldBe` status200
+
+                -- -- For debugging purposes you could do the following, to
+                -- -- see the HTML printed out on the terminal.
+                body <- responseBody response
+
+                let ctaBody = parseTags body
+                        |> getTagContent "div" ([("class", "prose md:prose-lg lg:prose-xl prose-headings:text-gray-700 max-w-3xl")] ==)
+                        |> innerText 
+
+                ctaBody `shouldBe` ""

--- a/Test/Main.hs
+++ b/Test/Main.hs
@@ -1,0 +1,12 @@
+module Main where
+
+import Test.Hspec
+import IHP.Prelude
+
+import Test.Controller.ParagraphCta
+import Test.SanitizeHtml
+
+main :: IO ()
+main = hspec do
+    Test.Controller.ParagraphCta.tests
+    Test.SanitizeHtml.tests

--- a/Test/SanitizeHtml.hs
+++ b/Test/SanitizeHtml.hs
@@ -1,0 +1,14 @@
+module Test.SanitizeHtml where
+
+import Test.Hspec
+import Web.Controller.ParagraphCtas
+
+tests :: Spec
+tests = describe "sanitizeHtml" do
+    it "Removes inline scripts" do
+        sanitizeHtml "<script>some1337Script(); doMoreHackerStuff();</script>" `shouldBe` ""
+        sanitizeHtml "<div><h1>GoodStuff</h1></div><script type=\"text/javascript\">var adr = '../evil.php?cakemonster=' + escape(document.cookie);</script>" `shouldBe` "<div><h1>GoodStuff</h1></div>"
+    it "Sanitizes XSS Using Script Via Encoded URI Schemes" do
+        sanitizeHtml "<html><body><img src=j&#X41vascript:alert('test2')></body></html>" `shouldBe` "<img>"
+    it "Sanitizes XSS Using Code Encoding" do
+        sanitizeHtml "<html><head><meta http-equiv=\"refresh\" content=\"0;url=data:text/html;base64,PHNjcmlwdD5hbGVydCgndGVzdDMnKTwvc2NyaXB0Pg\"></head><body>Hello</body></html>" `shouldBe` "Hello"

--- a/Web/Element/TinyMCE.hs
+++ b/Web/Element/TinyMCE.hs
@@ -1,0 +1,14 @@
+module Web.Element.TinyMCE where
+
+import Web.View.Prelude
+
+textareaWysiwygField :: forall fieldName model value.
+    ( ?formContext :: FormContext model
+    , HasField fieldName model value
+    , HasField "meta" model MetaBag
+    , KnownSymbol fieldName
+    , InputValue value
+    , KnownSymbol (GetModelName model)
+    ) => Proxy fieldName -> FormField
+textareaWysiwygField field = (textField field) { fieldType = TextareaInput, fieldInputId = "tinymce", required = True }
+{-# INLINE textareaWysiwygField #-}

--- a/Web/View/Layout.hs
+++ b/Web/View/Layout.hs
@@ -50,6 +50,8 @@ scripts = [hsx|
         <script src={assetPath "/vendor/turbolinksMorphdom.js"}></script>
         <!-- jsDelivr :: Sortable :: Latest (https://www.jsdelivr.com/package/npm/sortablejs) -->
         <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
+        <!-- TinyMCE Script -->
+        <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
         <script src={assetPath "/helpers.js"}></script>
         <script src={assetPath "/ihp-auto-refresh.js"}></script>
         <script src={assetPath "/app.js"}></script>

--- a/Web/View/ParagraphCtas/Edit.hs
+++ b/Web/View/ParagraphCtas/Edit.hs
@@ -2,6 +2,7 @@ module Web.View.ParagraphCtas.Edit where
 import Web.View.Prelude
 import Web.Element.Types
 import Web.Element.ElementWrap
+import Web.Element.TinyMCE
 
 
 data EditView = EditView
@@ -32,8 +33,8 @@ renderForm paragraphCta landingPages = formFor paragraphCta [hsx|
             visibleForm paragraphCta landingPages =
                 [hsx|
                     {(textField #title) {required = True}}
-                    {(textareaField #body) {required = True}}
-                     {(selectField #refLandingPageId landingPages) {required = True, fieldLabel = "Landing page", helpText = "Select the landing page you want to link to."}}
+                    {(textareaWysiwygField #body)}
+                    {(selectField #refLandingPageId landingPages) {required = True, fieldLabel = "Landing page", helpText = "Select the landing page you want to link to."}}
                     {submitButton}
                 |]
                 |> wrapVerticalSpacing AlignNone

--- a/Web/View/ParagraphCtas/New.hs
+++ b/Web/View/ParagraphCtas/New.hs
@@ -2,6 +2,7 @@ module Web.View.ParagraphCtas.New where
 import Web.View.Prelude
 import Web.Element.Types
 import Web.Element.ElementWrap
+import Web.Element.TinyMCE
 
 data NewView = NewView
     { paragraphCta :: ParagraphCta
@@ -31,8 +32,8 @@ renderForm paragraphCta landingPages = formFor paragraphCta [hsx|
             visibleForm paragraphCta landingPages =
                 [hsx|
                     {(textField #title) {required = True}}
-                    {(textareaField #body) {required = True}}
-                     {(selectField #refLandingPageId landingPages) {required = True, fieldLabel = "Landing page", helpText = "Select the landing page you want to link to."}}
+                    {(textareaWysiwygField #body)}
+                    {(selectField #refLandingPageId landingPages) {required = True, fieldLabel = "Landing page", helpText = "Select the landing page you want to link to."}}
                     {submitButton}
                 |]
                 |> wrapVerticalSpacing AlignNone

--- a/default.nix
+++ b/default.nix
@@ -15,6 +15,9 @@ let
             text
             hlint
             p.ihp
+            xss-sanitize
+            hspec
+            tagsoup
         ];
         otherDeps = p: with p; [
             # Native dependencies, e.g. imagemagick

--- a/static/app.js
+++ b/static/app.js
@@ -1,5 +1,4 @@
 $(document).on('ready turbolinks:load', () => {
-
     // Init sortable.
     document.querySelectorAll('.js-sortable').forEach(function (elem) {
         if (Boolean(elem.jsSortableInitialized) === false) {
@@ -9,5 +8,16 @@ $(document).on('ready turbolinks:load', () => {
             });
             elem.jsSortableInitialized = true;
         }
+    });
+
+    // Init TinyMCE
+    tinymce.remove();
+    tinymce.init({
+        selector: '#tinymce',
+        setup: function (editor) {
+            editor.on('change', function () {
+                editor.save();
+            });
+        },
     });
 });


### PR DESCRIPTION
- Add TinyMCE Cloud script to layout head
- Create a new TinyMCE element
- Add TinyMCE element to ParagraphCta new and edit forms
- Add new sanitizeHtml and sanitizeParagraphCTA functions for sanitizing HTML submitted via the WYSIWYG editor
- Add fullstack test for creating a new ParagraphCta, ensuring submitted HTML is sanitized
- Add pure unit tests for testing the functionality of sanitizeHtml function
- Add required dependencies for all of this to work:
  - xss-sanitize for implementing sanitizeHtml function
  - hspec for testing sanitizeHtml
  - tagsoup for testing sanitizeHtml